### PR TITLE
Remove .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: rust
-rust:
-  - nightly
-matrix:
-  allow_failures:
-    - rust: nightly
-os:
-  - linux


### PR DESCRIPTION
Remove .travis.yml because Travis CI's servers' cpu does not support avx2 and pikkr can not be built on them:

```
flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx rdtscp lm constant_tsc rep_good nopl xtopology cpuid pni pclmulqdq ssse3 cx16 pcid sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx f16c rdrand hypervisor lahf_lm fsgsbase smep erms xsaveopt
```