### PR TITLE
Shorten the length of a literal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "pikkr"
-version = "0.5.1"
+version = "0.5.3"
 dependencies = [
  "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "x86intrin 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pikkr"
-version = "0.5.2"
+version = "0.5.3"
 authors = ["Keiji Yoshida <kjmrknsn@gmail.com>"]
 description = "JSON Parser which picks up values directly without performing tokenization in Rust"
 documentation = "https://pikkr.github.io/doc/pikkr/"

--- a/src/index_builder.rs
+++ b/src/index_builder.rs
@@ -39,7 +39,7 @@ pub fn build_structural_quote_bitmap(b_backslash: &Vec<u64>, b_quote: &mut Vec<u
                         break;
                     }
                 } else {
-                    let backslash_b_mask = backslash_b & 0b11111111_11111111_11111111_11111111_11111111_11111111_11111111_11111111u64;
+                    let backslash_b_mask = backslash_b & 0xffffffffffffffffu64;
                     let leading_ones_num = (!backslash_b_mask).leading_zeros();
                     consecutive_backslash_num += leading_ones_num;
                     if leading_ones_num != 64 {


### PR DESCRIPTION
Shorten the length of a literal of index_builder::build_structural_quote_bitmap to improve readability.