### PR TITLE
Change the return type of `Pikkr::parse()`, to represents the parsing error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,9 @@ mod index_builder;
 mod parser;
 mod pikkr;
 mod query;
+mod result;
 mod stat;
 mod utf8;
 
+pub use result::{ParseError, ParseResult};
 pub use pikkr::Pikkr;

--- a/src/pikkr.rs
+++ b/src/pikkr.rs
@@ -266,7 +266,13 @@ mod tests {
                     }
                 "#,
                 want: vec![Some(r#""b""#.as_bytes()), None, None, None, None, None, None],
-            }
+            },
+            // for issue #10
+            TestCase {
+                rec: r#""#,
+                want: vec![None, None, None, None, None],
+            },
+
         ];
         for t in test_cases {
             let got = p.parse(t.rec.as_bytes());
@@ -332,7 +338,12 @@ mod tests {
             TestCase {
                 rec: r#"{}"#,
                 want: vec![None, None, None, None, None],
-            }
+            },
+            // for issue #10
+            TestCase {
+                rec: r#""#,
+                want: vec![None, None, None, None, None],
+            },
         ];
         for t in test_cases {
             let got = p.parse(t.rec.as_bytes());

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,0 +1,8 @@
+/// The error type represents all possible errors that occurs when parsing JSON string
+#[derive(Debug, PartialEq)]
+pub enum ParseError {
+    UnexpectedEof,
+}
+
+/// The type alias for `Result`, with the error type `ParseError`
+pub type ParseResult<T> = Result<T, ParseError>;


### PR DESCRIPTION
add the error type `ParseError`, which represents all possible errors that occurs when parse JSON string.

This PR also fixes #10.