### PR TITLE
Add test cases for issue tracker

### DIFF
--- a/src/pikkr.rs
+++ b/src/pikkr.rs
@@ -397,11 +397,6 @@ mod tests {
                     None,
                 ]),
             },
-            // for issue #10
-            TestCase {
-                rec: r#""#,
-                want: Err(Error::from(ErrorKind::InvalidRecord)),
-            },
         ];
         for t in test_cases {
             let got = p.parse(t.rec.as_bytes());
@@ -467,11 +462,6 @@ mod tests {
             TestCase {
                 rec: r#"{}"#,
                 want: Ok(vec![None, None, None, None, None]),
-            },
-            // for issue #10
-            TestCase {
-                rec: r#""#,
-                want: Err(Error::from(ErrorKind::InvalidRecord)),
             },
         ];
         for t in test_cases {

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -5,6 +5,10 @@ mod issues {
     use pikkr::Pikkr;
     use pikkr::ErrorKind;
 
+    /// The helper macro for test cases.
+    ///
+    /// The first argument is the parameters used in `Pikkr::new` and `Pikkr::parse`.
+    /// The remaining tokens after `=>` are used as the pattern to match success case.
     macro_rules! do_parse {
         ($p:expr => $($ptn:tt)*) => {{
             let res = Pikkr::new($p.0, $p.1).map(|mut p| p.parse($p.2));
@@ -22,6 +26,13 @@ mod issues {
         let t = 1;
         let r = "";
         do_parse!((q, t, r) => Ok(Err(ref e)) if e.kind() == ErrorKind::InvalidRecord);
+    }
+
+    #[test]
+    fn issue_15_panic_in_query_parser() {
+        let q = &["$"];
+        let t = 1;
+        do_parse!((q, t, "") => Err(ref e) if e.kind() == ErrorKind::InvalidQuery);
     }
 
     // test cases for unclosed issues.

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -1,0 +1,56 @@
+extern crate pikkr;
+
+#[allow(non_snake_case)]
+mod issues {
+    use pikkr::Pikkr;
+    use pikkr::ErrorKind;
+
+    macro_rules! do_parse {
+        ($p:expr => $($ptn:tt)*) => {{
+            let res = Pikkr::new($p.0, $p.1).map(|mut p| p.parse($p.2));
+            match res {
+                $($ptn)* => (),
+                r => panic!(concat!("The result {:?} does not match the pattern \"", stringify!($($ptn)*), "\""), r),
+            }
+        }}
+    }
+
+
+    #[test]
+    fn issue10_panic_on_empty_input() {
+        let q = &["$.a"];
+        let t = 1;
+        let r = "";
+        do_parse!((q, t, r) => Ok(Err(ref e)) if e.kind() == ErrorKind::InvalidRecord);
+    }
+
+    // test cases for unclosed issues.
+    // TODO: remove #[should_panic]
+
+    #[test]
+    #[should_panic]
+    fn issue11_panic_on_None_unwrapped_in_parser() {
+        let q = &["$.a"];
+        let t = 1;
+        let r = &[40, 0, 0, 0, 159, 159, 159, 0, 0, 0, 0, 58][..];
+        let _ = do_parse!((q, t, r) => Ok(_));
+    }
+
+    #[test]
+    #[should_panic]
+    fn issue12_panic_in_build_leveled_colon_bitmap() {
+        let q = &["$.a"];
+        let t = 1;
+        let r = b"(}";
+        let _ = do_parse!((q, t, r) => Ok(_));
+    }
+
+    #[test]
+    #[should_panic]
+    fn issue13_integer_overflow_in_parser() {
+        let q = &["$.a"];
+        let t = 1;
+        let r = b"\\\":";
+        let _ = do_parse!((q, t, r) => Ok(_));
+    }
+}


### PR DESCRIPTION
Note that some tese cases have the attribute `#[shoud_panic]` to avoid to panic itself, because some issues have not closed yet.  The attributes must be removed when the associated issue will be closed.