### PR TITLE
Fix ci.sh not to try to install rustfmt-nightly when it's already installed

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -2,7 +2,11 @@
 
 export RUSTFLAGS="-C target-cpu=native"
 
-cargo install rustfmt-nightly
+rustfmt_installed=$(cargo install --list | grep rustfmt-nightly | wc -l)
+
+if [ $rustfmt_installed -eq 0 ]; then
+    cargo install rustfmt-nightly
+fi
 cargo fmt -- --write-mode=diff
 cargo build --release
 cargo test --release


### PR DESCRIPTION
to avoid the following error:

```
$ ./ci.sh
    Updating registry `https://github.com/rust-lang/crates.io-index`
  Installing rustfmt-nightly v0.2.5
error: binary `cargo-fmt` already exists in destination as part of `rustfmt-nightly v0.2.5`
binary `rustfmt` already exists in destination as part of `rustfmt-nightly v0.2.5`
binary `rustfmt-format-diff` already exists in destination as part of `rustfmt-nightly v0.2.5`
Add --force to overwrite
```

https://travis-ci.org/pikkr/pikkr/builds/273190261