### PR TITLE
fixed some clippy warnings

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -6,7 +6,7 @@ use super::utf8::{COMMA, CR, HT, LF, RIGHT_BRACE, SPACE};
 use fnv::{FnvHashMap, FnvHashSet};
 
 #[inline]
-pub fn basic_parse<'a>(rec: &'a [u8], index: &Vec<Vec<u64>>, queries: &mut FnvHashMap<&[u8], Query>, start: usize, end: usize, level: usize, query_num: usize, stats: &mut Vec<FnvHashSet<usize>>, set_stats: bool, results: &mut Vec<Option<&'a [u8]>>, b_quote: &Vec<u64>) -> Result<()> {
+pub fn basic_parse<'a>(rec: &'a [u8], index: &[Vec<u64>], queries: &mut FnvHashMap<&[u8], Query>, start: usize, end: usize, level: usize, query_num: usize, stats: &mut Vec<FnvHashSet<usize>>, set_stats: bool, results: &mut Vec<Option<&'a [u8]>>, b_quote: &[u64]) -> Result<()> {
     let mut found_num = 0;
     let cp = generate_colon_positions(index, start, end, level);
     let mut vei = end;
@@ -68,7 +68,7 @@ pub fn basic_parse<'a>(rec: &'a [u8], index: &Vec<Vec<u64>>, queries: &mut FnvHa
 }
 
 #[inline]
-pub fn speculative_parse<'a>(rec: &'a [u8], index: &Vec<Vec<u64>>, queries: &FnvHashMap<&[u8], Query>, start: usize, end: usize, level: usize, stats: &Vec<FnvHashSet<usize>>, results: &mut Vec<Option<&'a [u8]>>, b_quote: &Vec<u64>) -> Result<bool> {
+pub fn speculative_parse<'a>(rec: &'a [u8], index: &[Vec<u64>], queries: &FnvHashMap<&[u8], Query>, start: usize, end: usize, level: usize, stats: &[FnvHashSet<usize>], results: &mut Vec<Option<&'a [u8]>>, b_quote: &[u64]) -> Result<bool> {
     let cp = generate_colon_positions(index, start, end, level);
     for (s, q) in queries.iter() {
         let mut found = false;
@@ -142,7 +142,7 @@ pub fn speculative_parse<'a>(rec: &'a [u8], index: &Vec<Vec<u64>>, queries: &Fnv
 }
 
 #[inline]
-fn generate_colon_positions(index: &Vec<Vec<u64>>, start: usize, end: usize, level: usize) -> Vec<usize> {
+fn generate_colon_positions(index: &[Vec<u64>], start: usize, end: usize, level: usize) -> Vec<usize> {
     let mut c = Vec::new();
     for i in start / 64..(end + 63) / 64 {
         let mut m_colon = index[level][i];
@@ -155,11 +155,11 @@ fn generate_colon_positions(index: &Vec<Vec<u64>>, start: usize, end: usize, lev
             m_colon = bit::r(m_colon);
         }
     }
-    return c;
+    c
 }
 
 #[inline]
-fn search_pre_field_indices(b_quote: &Vec<u64>, start: usize, end: usize) -> Result<(usize, usize)> {
+fn search_pre_field_indices(b_quote: &[u64], start: usize, end: usize) -> Result<(usize, usize)> {
     let mut si = 0;
     let mut ei = 0;
     let mut ei_set = false;

--- a/src/pikkr.rs
+++ b/src/pikkr.rs
@@ -98,7 +98,7 @@ impl<'a> Pikkr<'a> {
         let mut b_right = Vec::with_capacity(b_len);
 
         index_builder::build_structural_character_bitmap(
-            &rec,
+            rec,
             &mut b_backslash,
             &mut b_quote,
             &mut b_colon,
@@ -195,11 +195,9 @@ impl<'a> Pikkr<'a> {
 
 
 #[inline]
-fn is_valid_query_str<'a>(query_str: &'a [u8]) -> bool {
-    if query_str.len() < ROOT_QUERY_STR_OFFSET + 1 {
-        return false;
-    }
-    if query_str[0] != DOLLAR || query_str[1] != DOT {
+fn is_valid_query_str(query_str: &[u8]) -> bool {
+    if query_str.len() < ROOT_QUERY_STR_OFFSET + 1 ||
+       query_str[0] != DOLLAR || query_str[1] != DOT {
         return false;
     }
     let mut s = ROOT_QUERY_STR_OFFSET - 1;
@@ -207,10 +205,7 @@ fn is_valid_query_str<'a>(query_str: &'a [u8]) -> bool {
         if query_str[i] != DOT {
             continue;
         }
-        if i == s + 1 {
-            return false;
-        }
-        if i == query_str.len() - 1 {
+        if i == s + 1 || i == query_str.len() - 1 {
             return false;
         }
         s = i;
@@ -395,8 +390,8 @@ mod tests {
             },
             TestCase {
                 rec: r#"
-                    	{
-                     	"f1" 	 : 	 "b"
+                        {
+                        "f1"     :   "b"
                     }
                 "#,
                 want: Ok(vec![

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -43,7 +43,7 @@ mod issues {
         let q = &["$.a"];
         let t = 1;
         let r = &[40, 0, 0, 0, 159, 159, 159, 0, 0, 0, 0, 58][..];
-        let _ = do_parse!((q, t, r) => Ok(Err(ref e)) if e.kind() == ErrorKind::InvalidRecord);
+        do_parse!((q, t, r) => Ok(Err(ref e)) if e.kind() == ErrorKind::InvalidRecord);
     }
 
     #[test]
@@ -51,7 +51,7 @@ mod issues {
         let q = &["$.a"];
         let t = 1;
         let r = b"(}";
-        let _ = do_parse!((q, t, r) => Ok(Err(ref e)) if e.kind() == ErrorKind::InvalidRecord);
+        do_parse!((q, t, r) => Ok(Err(ref e)) if e.kind() == ErrorKind::InvalidRecord);
     }
 
     #[test]
@@ -59,6 +59,6 @@ mod issues {
         let q = &["$.a"];
         let t = 1;
         let r = b"\\\":";
-        let _ = do_parse!((q, t, r) => Ok(Err(ref e)) if e.kind() == ErrorKind::InvalidRecord);
+        do_parse!((q, t, r) => Ok(Err(ref e)) if e.kind() == ErrorKind::InvalidRecord);
     }
 }


### PR DESCRIPTION
Mostly readability, but changing an indexed loop to an iterator one can elide a bounds check, so it should at least be as fast as before.