### PR TITLE
refactor: move some codes associated with the pattern tree into query.rs

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -29,6 +29,7 @@ pub fn basic_parse<'a>(rec: &'a [u8], index: &[Vec<u64>], queries: &mut FnvHashM
                 stats[query.i].insert(i);
             }
             if let Some(ref mut children) = query.children {
+                let children_len = children.len();
                 basic_parse(
                     rec,
                     index,
@@ -36,7 +37,7 @@ pub fn basic_parse<'a>(rec: &'a [u8], index: &[Vec<u64>], queries: &mut FnvHashM
                     vsi,
                     vei,
                     level + 1,
-                    query.children_len,
+                    children_len,
                     stats,
                     set_stats,
                     results,
@@ -259,7 +260,6 @@ mod tests {
                 ri: 0,
                 target: true,
                 children: None,
-                children_len: 0,
             },
         );
         children.insert(
@@ -269,10 +269,8 @@ mod tests {
                 ri: 1,
                 target: true,
                 children: None,
-                children_len: 0,
             },
         );
-        let children_len = children.len();
         let mut queries = FnvHashMap::default();
         queries.insert(
             "aaa".as_bytes(),
@@ -281,7 +279,6 @@ mod tests {
                 ri: 2,
                 target: true,
                 children: None,
-                children_len: 0,
             },
         );
         queries.insert(
@@ -291,7 +288,6 @@ mod tests {
                 ri: 3,
                 target: true,
                 children: None,
-                children_len: 0,
             },
         );
         queries.insert(
@@ -301,7 +297,6 @@ mod tests {
                 ri: 4,
                 target: true,
                 children: None,
-                children_len: 0,
             },
         );
         queries.insert(
@@ -311,7 +306,6 @@ mod tests {
                 ri: 0,
                 target: false,
                 children: Some(children),
-                children_len: children_len,
             },
         );
         queries.insert(
@@ -321,7 +315,6 @@ mod tests {
                 ri: 5,
                 target: true,
                 children: None,
-                children_len: 0,
             },
         );
 

--- a/src/pikkr.rs
+++ b/src/pikkr.rs
@@ -153,6 +153,7 @@ impl<'a> Pikkr<'a> {
                 &self.b_quote,
             )?;
             if !found {
+                let queries_len = self.queries.root.len();
                 parser::basic_parse(
                     rec,
                     &self.index,
@@ -160,7 +161,7 @@ impl<'a> Pikkr<'a> {
                     0,
                     rec.len() - 1,
                     0,
-                    self.queries.num_children,
+                    queries_len,
                     &mut self.stats,
                     false,
                     &mut results,
@@ -168,6 +169,7 @@ impl<'a> Pikkr<'a> {
                 )?;
             }
         } else {
+            let queries_len = self.queries.root.len();
             parser::basic_parse(
                 rec,
                 &self.index,
@@ -175,7 +177,7 @@ impl<'a> Pikkr<'a> {
                 0,
                 rec.len() - 1,
                 0,
-                self.queries.num_children,
+                queries_len,
                 &mut self.stats,
                 true,
                 &mut results,

--- a/src/pikkr.rs
+++ b/src/pikkr.rs
@@ -138,13 +138,13 @@ impl<'a> Pikkr<'a> {
 
         self.build_structural_indices(rec)?;
 
-        let mut results = vec![None; self.queries.query_strs_len];
+        let mut results = vec![None; self.queries.num_queries];
 
         if self.trained {
             let found = parser::speculative_parse(
                 rec,
                 &self.index,
-                &self.queries.queries,
+                &self.queries.root,
                 0,
                 rec.len() - 1,
                 0,
@@ -156,11 +156,11 @@ impl<'a> Pikkr<'a> {
                 parser::basic_parse(
                     rec,
                     &self.index,
-                    &mut self.queries.queries,
+                    &mut self.queries.root,
                     0,
                     rec.len() - 1,
                     0,
-                    self.queries.queries_len,
+                    self.queries.num_children,
                     &mut self.stats,
                     false,
                     &mut results,
@@ -171,11 +171,11 @@ impl<'a> Pikkr<'a> {
             parser::basic_parse(
                 rec,
                 &self.index,
-                &mut self.queries.queries,
+                &mut self.queries.root,
                 0,
                 rec.len() - 1,
                 0,
-                self.queries.queries_len,
+                self.queries.num_children,
                 &mut self.stats,
                 true,
                 &mut results,

--- a/src/pikkr.rs
+++ b/src/pikkr.rs
@@ -40,8 +40,8 @@ impl<'a> Pikkr<'a> {
     pub fn new<S: ?Sized + AsRef<[u8]>>(query_strs: &[&'a S], train_num: usize) -> Result<Pikkr<'a>> {
         let queries = QueryTree::new(query_strs)?;
 
-        let index = vec![Vec::new(); queries.level];
-        let stats = vec![Default::default(); queries.qi];
+        let index = vec![Vec::new(); queries.max_depth];
+        let stats = vec![Default::default(); queries.num_nodes];
 
         Ok(Pikkr {
             backslash: avx::mm256i(BACKSLASH as i8),
@@ -123,7 +123,7 @@ impl<'a> Pikkr<'a> {
             &self.b_colon,
             &self.b_left,
             &self.b_right,
-            self.queries.level,
+            self.queries.max_depth,
             &mut self.index,
         )
     }

--- a/src/pikkr.rs
+++ b/src/pikkr.rs
@@ -2,14 +2,11 @@ use super::avx;
 use super::error::{Error, ErrorKind};
 use super::index_builder;
 use super::parser;
-use super::query::Query;
+use super::query::QueryTree;
 use super::result::Result;
-use super::utf8::{BACKSLASH, COLON, DOLLAR, DOT, LEFT_BRACE, QUOTE, RIGHT_BRACE};
-use std::cmp;
-use fnv::{FnvHashMap, FnvHashSet};
+use super::utf8::{BACKSLASH, COLON, LEFT_BRACE, QUOTE, RIGHT_BRACE};
+use fnv::FnvHashSet;
 use x86intrin::m256i;
-
-const ROOT_QUERY_STR_OFFSET: usize = 2;
 
 /// JSON parser which picks up values directly without performing tokenization
 pub struct Pikkr<'a> {
@@ -19,10 +16,7 @@ pub struct Pikkr<'a> {
     left_brace: m256i,
     right_brace: m256i,
 
-    query_strs_len: usize,
-    queries: FnvHashMap<&'a [u8], Query<'a>>,
-    queries_len: usize,
-    level: usize,
+    queries: QueryTree<'a>,
 
     b_backslash: Vec<u64>,
     b_quote: Vec<u64>,
@@ -44,21 +38,19 @@ impl<'a> Pikkr<'a> {
     /// Creates a JSON parser and returns it.
     #[inline]
     pub fn new<S: ?Sized + AsRef<[u8]>>(query_strs: &[&'a S], train_num: usize) -> Result<Pikkr<'a>> {
-        if query_strs.iter().any(|s| !is_valid_query_str(s.as_ref())) {
-            return Err(Error::from(ErrorKind::InvalidQuery));
-        }
+        let queries = QueryTree::new(query_strs)?;
 
-        let mut p = Pikkr {
+        let index = vec![Vec::new(); queries.level];
+        let stats = vec![Default::default(); queries.qi];
+
+        Ok(Pikkr {
             backslash: avx::mm256i(BACKSLASH as i8),
             quote: avx::mm256i(QUOTE as i8),
             colon: avx::mm256i(COLON as i8),
             left_brace: avx::mm256i(LEFT_BRACE as i8),
             right_brace: avx::mm256i(RIGHT_BRACE as i8),
 
-            query_strs_len: query_strs.len(),
-            queries: FnvHashMap::default(),
-            queries_len: 0,
-            level: 0,
+            queries,
 
             b_backslash: Vec::new(),
             b_quote: Vec::new(),
@@ -67,37 +59,14 @@ impl<'a> Pikkr<'a> {
             b_right: Vec::new(),
             b_string_mask: Vec::new(),
 
-            index: Vec::new(),
+            index,
 
             train_num,
             trained_num: 0,
             trained: false,
 
-            stats: Vec::new(),
-        };
-
-        let mut qi = 0;
-        for (ri, query_str) in query_strs.iter().enumerate() {
-            let (level, next_qi) = set_queries(
-                &mut p.queries,
-                (*query_str).as_ref(),
-                ROOT_QUERY_STR_OFFSET,
-                qi,
-                ri,
-            );
-            p.level = cmp::max(p.level, level);
-            qi = next_qi;
-        }
-
-        p.queries_len = p.queries.len();
-
-        p.index = vec![Vec::new(); p.level];
-
-        for _ in 0..qi {
-            p.stats.push(FnvHashSet::default());
-        }
-
-        Ok(p)
+            stats,
+        })
     }
 
     #[inline(always)]
@@ -154,7 +123,7 @@ impl<'a> Pikkr<'a> {
             &self.b_colon,
             &self.b_left,
             &self.b_right,
-            self.level,
+            self.queries.level,
             &mut self.index,
         )
     }
@@ -169,13 +138,13 @@ impl<'a> Pikkr<'a> {
 
         self.build_structural_indices(rec)?;
 
-        let mut results = vec![None; self.query_strs_len];
+        let mut results = vec![None; self.queries.query_strs_len];
 
         if self.trained {
             let found = parser::speculative_parse(
                 rec,
                 &self.index,
-                &self.queries,
+                &self.queries.queries,
                 0,
                 rec.len() - 1,
                 0,
@@ -187,11 +156,11 @@ impl<'a> Pikkr<'a> {
                 parser::basic_parse(
                     rec,
                     &self.index,
-                    &mut self.queries,
+                    &mut self.queries.queries,
                     0,
                     rec.len() - 1,
                     0,
-                    self.queries_len,
+                    self.queries.queries_len,
                     &mut self.stats,
                     false,
                     &mut results,
@@ -202,11 +171,11 @@ impl<'a> Pikkr<'a> {
             parser::basic_parse(
                 rec,
                 &self.index,
-                &mut self.queries,
+                &mut self.queries.queries,
                 0,
                 rec.len() - 1,
                 0,
-                self.queries_len,
+                self.queries.queries_len,
                 &mut self.stats,
                 true,
                 &mut results,
@@ -220,68 +189,6 @@ impl<'a> Pikkr<'a> {
 
         Ok(results)
     }
-}
-
-
-#[inline]
-fn is_valid_query_str(query_str: &[u8]) -> bool {
-    if query_str.len() < ROOT_QUERY_STR_OFFSET + 1 || query_str[0] != DOLLAR || query_str[1] != DOT {
-        return false;
-    }
-    let mut s = ROOT_QUERY_STR_OFFSET - 1;
-    for i in s + 1..query_str.len() {
-        if query_str[i] != DOT {
-            continue;
-        }
-        if i == s + 1 || i == query_str.len() - 1 {
-            return false;
-        }
-        s = i;
-    }
-    true
-}
-
-#[inline]
-fn set_queries<'a>(queries: &mut FnvHashMap<&'a [u8], Query<'a>>, s: &'a [u8], i: usize, qi: usize, ri: usize) -> (usize, usize) {
-    for j in i..s.len() {
-        if s[j] == DOT {
-            let t = &s[i..j];
-            let query = queries.entry(t).or_insert(Query {
-                i: qi,
-                ri: ri,
-                target: false,
-                children: None,
-                children_len: 0,
-            });
-            let mut children = query.children.get_or_insert(FnvHashMap::default());
-            let (child_level, next_qi) = set_queries(
-                &mut children,
-                s,
-                j + 1,
-                if qi == query.i { qi + 1 } else { qi },
-                ri,
-            );
-            query.children_len = children.len();
-            return (child_level + 1, next_qi);
-        }
-    }
-    let t = &s[i..];
-    if !queries.contains_key(t) {
-        queries.insert(
-            t,
-            Query {
-                i: qi,
-                ri: ri,
-                target: true,
-                children: None,
-                children_len: 0,
-            },
-        );
-        return (1, qi + 1);
-    } else {
-        queries.get_mut(t).unwrap().target = true;
-    }
-    (1, qi)
 }
 
 #[cfg(test)]
@@ -498,68 +405,6 @@ mod tests {
         ];
         for t in test_cases {
             let got = p.parse(t.rec.as_bytes());
-            assert_eq!(t.want, got);
-        }
-    }
-
-    #[test]
-    fn test_is_valid_query_str() {
-        struct TestCase<'a> {
-            query_str: &'a str,
-            want: bool,
-        }
-        let test_cases = vec![
-            TestCase {
-                query_str: "",
-                want: false,
-            },
-            TestCase {
-                query_str: "$",
-                want: false,
-            },
-            TestCase {
-                query_str: "$.",
-                want: false,
-            },
-            TestCase {
-                query_str: "$..",
-                want: false,
-            },
-            TestCase {
-                query_str: "a.a",
-                want: false,
-            },
-            TestCase {
-                query_str: "$aa",
-                want: false,
-            },
-            TestCase {
-                query_str: "$.a",
-                want: true,
-            },
-            TestCase {
-                query_str: "$.aaaa",
-                want: true,
-            },
-            TestCase {
-                query_str: "$.aaaa.",
-                want: false,
-            },
-            TestCase {
-                query_str: "$.aaaa.b",
-                want: true,
-            },
-            TestCase {
-                query_str: "$.aaaa.bbbb",
-                want: true,
-            },
-            TestCase {
-                query_str: "$.aaaa.bbbb.",
-                want: false,
-            },
-        ];
-        for t in test_cases {
-            let got = is_valid_query_str(t.query_str.as_bytes());
             assert_eq!(t.want, got);
         }
     }

--- a/src/query.rs
+++ b/src/query.rs
@@ -19,9 +19,8 @@ pub struct Query<'a> {
 pub struct QueryTree<'a> {
     pub root: FnvHashMap<&'a [u8], Query<'a>>,
     pub num_queries: usize,
-
-    pub level: usize,
-    pub qi: usize,
+    pub max_depth: usize,
+    pub num_nodes: usize,
 }
 
 impl<'a> QueryTree<'a> {
@@ -42,8 +41,8 @@ impl<'a> QueryTree<'a> {
         Ok(Self {
             root,
             num_queries: queries.len(),
-            level,
-            qi,
+            max_depth: level,
+            num_nodes: qi,
         })
     }
 }
@@ -81,8 +80,12 @@ fn set_queries<'a>(queries: &mut FnvHashMap<&'a [u8], Query<'a>>, s: &'a [u8], q
                 *qi += 1;
                 query
             });
-            let mut children = query.children.get_or_insert(FnvHashMap::default());
-            return set_queries(&mut children, &u[1..], qi, ri) + 1;
+            return set_queries(
+                query.children.get_or_insert(FnvHashMap::default()),
+                &u[1..],
+                qi,
+                ri,
+            ) + 1;
         }
     }
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,4 +1,11 @@
+use std::cmp;
 use fnv::FnvHashMap;
+use error::{Error, ErrorKind};
+use result::Result;
+use utf8::{DOLLAR, DOT};
+
+const ROOT_QUERY_STR_OFFSET: usize = 2;
+
 
 #[derive(Debug)]
 pub struct Query<'a> {
@@ -7,4 +14,176 @@ pub struct Query<'a> {
     pub target: bool,
     pub children: Option<FnvHashMap<&'a [u8], Query<'a>>>,
     pub children_len: usize,
+}
+
+/// A pattern tree associated with the queries
+pub struct QueryTree<'a> {
+    pub queries: FnvHashMap<&'a [u8], Query<'a>>,
+    pub queries_len: usize,
+    pub query_strs_len: usize,
+
+    pub level: usize,
+    pub qi: usize,
+}
+
+impl<'a> QueryTree<'a> {
+    pub fn new<S: ?Sized + AsRef<[u8]>>(query_strs: &[&'a S]) -> Result<Self> {
+        let mut queries = FnvHashMap::default();
+        let mut level = 0;
+        let mut qi = 0;
+
+        for (ri, query_str) in query_strs.iter().enumerate() {
+            if !is_valid_query_str(query_str.as_ref()) {
+                return Err(Error::from(ErrorKind::InvalidQuery));
+            }
+
+            let (l, next_qi) = set_queries(
+                &mut queries,
+                (*query_str).as_ref(),
+                ROOT_QUERY_STR_OFFSET,
+                qi,
+                ri,
+            );
+            level = cmp::max(level, l);
+            qi = next_qi;
+        }
+
+        let queries_len = queries.len();
+
+        Ok(Self {
+            query_strs_len: query_strs.len(),
+            queries,
+            queries_len,
+            level,
+            qi,
+        })
+    }
+}
+
+#[inline]
+fn is_valid_query_str(query_str: &[u8]) -> bool {
+    if query_str.len() < ROOT_QUERY_STR_OFFSET + 1 || query_str[0] != DOLLAR || query_str[1] != DOT {
+        return false;
+    }
+    let mut s = ROOT_QUERY_STR_OFFSET - 1;
+    for i in s + 1..query_str.len() {
+        if query_str[i] != DOT {
+            continue;
+        }
+        if i == s + 1 || i == query_str.len() - 1 {
+            return false;
+        }
+        s = i;
+    }
+    true
+}
+
+#[inline]
+fn set_queries<'a>(queries: &mut FnvHashMap<&'a [u8], Query<'a>>, s: &'a [u8], i: usize, qi: usize, ri: usize) -> (usize, usize) {
+    for j in i..s.len() {
+        if s[j] == DOT {
+            let t = &s[i..j];
+            let query = queries.entry(t).or_insert(Query {
+                i: qi,
+                ri: ri,
+                target: false,
+                children: None,
+                children_len: 0,
+            });
+            let mut children = query.children.get_or_insert(FnvHashMap::default());
+            let (child_level, next_qi) = set_queries(
+                &mut children,
+                s,
+                j + 1,
+                if qi == query.i { qi + 1 } else { qi },
+                ri,
+            );
+            query.children_len = children.len();
+            return (child_level + 1, next_qi);
+        }
+    }
+    let t = &s[i..];
+    if !queries.contains_key(t) {
+        queries.insert(
+            t,
+            Query {
+                i: qi,
+                ri: ri,
+                target: true,
+                children: None,
+                children_len: 0,
+            },
+        );
+        return (1, qi + 1);
+    } else {
+        queries.get_mut(t).unwrap().target = true;
+    }
+    (1, qi)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_valid_query_str() {
+        struct TestCase<'a> {
+            query_str: &'a str,
+            want: bool,
+        }
+        let test_cases = vec![
+            TestCase {
+                query_str: "",
+                want: false,
+            },
+            TestCase {
+                query_str: "$",
+                want: false,
+            },
+            TestCase {
+                query_str: "$.",
+                want: false,
+            },
+            TestCase {
+                query_str: "$..",
+                want: false,
+            },
+            TestCase {
+                query_str: "a.a",
+                want: false,
+            },
+            TestCase {
+                query_str: "$aa",
+                want: false,
+            },
+            TestCase {
+                query_str: "$.a",
+                want: true,
+            },
+            TestCase {
+                query_str: "$.aaaa",
+                want: true,
+            },
+            TestCase {
+                query_str: "$.aaaa.",
+                want: false,
+            },
+            TestCase {
+                query_str: "$.aaaa.b",
+                want: true,
+            },
+            TestCase {
+                query_str: "$.aaaa.bbbb",
+                want: true,
+            },
+            TestCase {
+                query_str: "$.aaaa.bbbb.",
+                want: false,
+            },
+        ];
+        for t in test_cases {
+            let got = is_valid_query_str(t.query_str.as_bytes());
+            assert_eq!(t.want, got);
+        }
+    }
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -86,19 +86,17 @@ fn set_queries<'a>(queries: &mut FnvHashMap<&'a [u8], Query<'a>>, s: &'a [u8], q
         }
     }
 
-    if !queries.contains_key(s) {
-        queries.insert(
-            s,
-            Query {
-                i: *qi,
-                ri: ri,
-                target: false,
-                children: None,
-            },
-        );
+    let query = queries.entry(s).or_insert_with(|| {
+        let query = Query {
+            i: *qi,
+            ri: ri,
+            target: false,
+            children: None,
+        };
         *qi += 1;
-    }
-    queries.get_mut(s).unwrap().target = true;
+        query
+    });
+    query.target = true;
     1
 }
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -13,13 +13,11 @@ pub struct Query<'a> {
     pub ri: usize,
     pub target: bool,
     pub children: Option<FnvHashMap<&'a [u8], Query<'a>>>,
-    pub children_len: usize,
 }
 
 /// A pattern tree associated with the queries
 pub struct QueryTree<'a> {
     pub root: FnvHashMap<&'a [u8], Query<'a>>,
-    pub num_children: usize,
     pub num_queries: usize,
 
     pub level: usize,
@@ -42,11 +40,8 @@ impl<'a> QueryTree<'a> {
             qi = next_qi;
         }
 
-        let num_children = root.len();
-
         Ok(Self {
             root,
-            num_children,
             num_queries: queries.len(),
             level,
             qi,
@@ -82,7 +77,6 @@ fn set_queries<'a>(queries: &mut FnvHashMap<&'a [u8], Query<'a>>, s: &'a [u8], i
                 ri: ri,
                 target: false,
                 children: None,
-                children_len: 0,
             });
             let mut children = query.children.get_or_insert(FnvHashMap::default());
             let (child_level, next_qi) = set_queries(
@@ -92,7 +86,6 @@ fn set_queries<'a>(queries: &mut FnvHashMap<&'a [u8], Query<'a>>, s: &'a [u8], i
                 if qi == query.i { qi + 1 } else { qi },
                 ri,
             );
-            query.children_len = children.len();
             return (child_level + 1, next_qi);
         }
     }
@@ -105,7 +98,6 @@ fn set_queries<'a>(queries: &mut FnvHashMap<&'a [u8], Query<'a>>, s: &'a [u8], i
                 ri: ri,
                 target: true,
                 children: None,
-                children_len: 0,
             },
         );
         return (1, qi + 1);


### PR DESCRIPTION
A new struct `QueryTree<'a>` is the instance of a pattern tree, introduced in section 5.1 of the paper.