### PR TITLE
Refactor: define a new struct `Parser` to manage parser context

### DIFF
--- a/src/index_builder.rs
+++ b/src/index_builder.rs
@@ -15,7 +15,7 @@ pub struct IndexBuilder {
     right_brace: m256i,
 
     b_backslash: Vec<u64>,
-    b_quote: Vec<u64>,
+    pub(crate) b_quote: Vec<u64>,
     b_colon: Vec<u64>,
     b_left: Vec<u64>,
     b_right: Vec<u64>,
@@ -23,7 +23,7 @@ pub struct IndexBuilder {
 
     s_left: Vec<(usize, u64)>,
 
-    index: Vec<Vec<u64>>,
+    pub(crate) index: Vec<Vec<u64>>,
     depth: usize,
 }
 
@@ -110,14 +110,6 @@ impl IndexBuilder {
             &mut self.s_left,
             &mut self.index,
         )
-    }
-
-    pub fn index(&self) -> &[Vec<u64>] {
-        &self.index
-    }
-
-    pub fn b_quote(&self) -> &[u64] {
-        &self.b_quote
     }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -9,7 +9,7 @@ use fnv::{FnvHashMap, FnvHashSet};
 pub fn basic_parse<'a>(
     rec: &'a [u8],
     index: &[Vec<u64>],
-    queries: &mut FnvHashMap<&[u8], Query>,
+    queries: &FnvHashMap<&[u8], Query>,
     start: usize,
     end: usize,
     level: usize,
@@ -21,7 +21,6 @@ pub fn basic_parse<'a>(
 ) -> Result<()> {
     generate_colon_positions(index, start, end, level, colon_positions);
 
-    let query_num = queries.len();
     let mut found_num = 0;
     let mut vei = end;
     let cp_len = colon_positions[level].len();
@@ -36,7 +35,7 @@ pub fn basic_parse<'a>(
             colon_positions[level][i],
         )?;
         let field = &rec[fsi + 1..fei];
-        if let Some(query) = queries.get_mut(field) {
+        if let Some(query) = queries.get(field) {
             let (vsi, vei) = search_post_value_indices(
                 rec,
                 colon_positions[level][i] + 1,
@@ -47,7 +46,7 @@ pub fn basic_parse<'a>(
             if set_stats && !stats[query.i].contains(&i) {
                 stats[query.i].insert(i);
             }
-            if let Some(ref mut children) = query.children {
+            if let Some(ref children) = query.children {
                 basic_parse(
                     rec,
                     index,
@@ -65,7 +64,7 @@ pub fn basic_parse<'a>(
             if query.target {
                 results[query.ri] = Some(&rec[vsi..vei + 1]);
             }
-            if found_num == query_num {
+            if found_num == queries.len() {
                 return Ok(());
             }
         }

--- a/src/pikkr.rs
+++ b/src/pikkr.rs
@@ -67,20 +67,20 @@ impl<'a> Pikkr<'a> {
         let mut results = vec![None; self.queries.num_queries];
         let found = parser::speculative_parse(
             rec,
-            &self.index_builder.index(),
+            &self.index_builder.index,
             &self.queries.root,
             0,
             rec.len() - 1,
             0,
             &self.stats,
             &mut results,
-            &self.index_builder.b_quote(),
+            &self.index_builder.b_quote,
             &mut self.colon_positions,
         )?;
         if !found {
             parser::basic_parse(
                 rec,
-                &self.index_builder.index(),
+                &self.index_builder.index,
                 &mut self.queries.root,
                 0,
                 rec.len() - 1,
@@ -88,7 +88,7 @@ impl<'a> Pikkr<'a> {
                 &mut self.stats,
                 false,
                 &mut results,
-                &self.index_builder.b_quote(),
+                &self.index_builder.b_quote,
                 &mut self.colon_positions,
             )?;
         }
@@ -99,7 +99,7 @@ impl<'a> Pikkr<'a> {
         let mut results = vec![None; self.queries.num_queries];
         parser::basic_parse(
             rec,
-            &self.index_builder.index(),
+            &self.index_builder.index,
             &mut self.queries.root,
             0,
             rec.len() - 1,
@@ -107,7 +107,7 @@ impl<'a> Pikkr<'a> {
             &mut self.stats,
             true,
             &mut results,
-            &self.index_builder.b_quote(),
+            &self.index_builder.b_quote,
             &mut self.colon_positions,
         )?;
         Ok(results)

--- a/src/pikkr.rs
+++ b/src/pikkr.rs
@@ -1,17 +1,12 @@
 use super::error::{Error, ErrorKind};
-use super::index_builder::IndexBuilder;
-use super::parser;
+use super::parser::{self, Parser};
 use super::query::QueryTree;
 use super::result::Result;
-use fnv::FnvHashSet;
 
 /// JSON parser which picks up values directly without performing tokenization
 pub struct Pikkr<'a> {
     queries: QueryTree<'a>,
-    index_builder: IndexBuilder,
-
-    stats: Vec<FnvHashSet<usize>>,
-    colon_positions: Vec<Vec<usize>>,
+    parser: Parser,
 
     train_num: usize,
     trained_num: usize,
@@ -23,17 +18,11 @@ impl<'a> Pikkr<'a> {
     #[inline]
     pub fn new<S: ?Sized + AsRef<[u8]>>(query_strs: &[&'a S], train_num: usize) -> Result<Pikkr<'a>> {
         let queries = QueryTree::new(query_strs)?;
-
-        let index_builder = IndexBuilder::new(queries.max_depth);
-        let colon_positions = vec![Vec::new(); queries.max_depth];
-        let stats = vec![Default::default(); queries.num_nodes];
+        let parser = Parser::new(queries.max_depth, queries.num_nodes);
 
         Ok(Pikkr {
             queries,
-            index_builder,
-
-            stats,
-            colon_positions,
+            parser,
 
             train_num,
             trained_num: 0,
@@ -49,7 +38,7 @@ impl<'a> Pikkr<'a> {
             return Err(Error::from(ErrorKind::InvalidRecord));
         }
 
-        self.index_builder.build_structural_indices(rec)?;
+        self.parser.index_builder.build_structural_indices(rec)?;
 
         if self.trained {
             self.speculative_parse(rec)
@@ -66,30 +55,24 @@ impl<'a> Pikkr<'a> {
     fn speculative_parse<'b>(&mut self, rec: &'b [u8]) -> Result<Vec<Option<&'b [u8]>>> {
         let mut results = vec![None; self.queries.num_queries];
         let found = parser::speculative_parse(
+            &self.parser,
             rec,
-            &self.index_builder.index,
             &self.queries.root,
             0,
             rec.len() - 1,
             0,
-            &self.stats,
             &mut results,
-            &self.index_builder.b_quote,
-            &mut self.colon_positions,
         )?;
         if !found {
             parser::basic_parse(
+                &mut self.parser,
                 rec,
-                &self.index_builder.index,
-                &mut self.queries.root,
+                &self.queries.root,
                 0,
                 rec.len() - 1,
                 0,
-                &mut self.stats,
                 false,
                 &mut results,
-                &self.index_builder.b_quote,
-                &mut self.colon_positions,
             )?;
         }
         Ok(results)
@@ -98,17 +81,14 @@ impl<'a> Pikkr<'a> {
     fn basic_parse<'b>(&mut self, rec: &'b [u8]) -> Result<Vec<Option<&'b [u8]>>> {
         let mut results = vec![None; self.queries.num_queries];
         parser::basic_parse(
+            &mut self.parser,
             rec,
-            &self.index_builder.index,
-            &mut self.queries.root,
+            &self.queries.root,
             0,
             rec.len() - 1,
             0,
-            &mut self.stats,
             true,
             &mut results,
-            &self.index_builder.b_quote,
-            &mut self.colon_positions,
         )?;
         Ok(results)
     }

--- a/src/pikkr.rs
+++ b/src/pikkr.rs
@@ -1,5 +1,5 @@
 use super::error::{Error, ErrorKind};
-use super::parser::{self, Parser};
+use super::parser::Parser;
 use super::query::QueryTree;
 use super::result::Result;
 
@@ -54,18 +54,10 @@ impl<'a> Pikkr<'a> {
 
     fn speculative_parse<'b>(&mut self, rec: &'b [u8]) -> Result<Vec<Option<&'b [u8]>>> {
         let mut results = vec![None; self.queries.num_queries];
-        let found = parser::speculative_parse(
-            &self.parser,
-            rec,
-            &self.queries.root,
-            0,
-            rec.len() - 1,
-            0,
-            &mut results,
-        )?;
+        let found = self.parser
+            .speculative_parse(rec, &self.queries.root, 0, rec.len() - 1, 0, &mut results)?;
         if !found {
-            parser::basic_parse(
-                &mut self.parser,
+            self.parser.basic_parse(
                 rec,
                 &self.queries.root,
                 0,
@@ -80,8 +72,7 @@ impl<'a> Pikkr<'a> {
 
     fn basic_parse<'b>(&mut self, rec: &'b [u8]) -> Result<Vec<Option<&'b [u8]>>> {
         let mut results = vec![None; self.queries.num_queries];
-        parser::basic_parse(
-            &mut self.parser,
+        self.parser.basic_parse(
             rec,
             &self.queries.root,
             0,


### PR DESCRIPTION
Note that `Parser` has an internal mutability for `colon_positions`, to avoid the compiler error by borrow checker.  It will add some runtime costs due to `RefCell`, but its cost is negligibly small as far as I measured.