### PR TITLE
allow build without AVX

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ keywords = ["pikkr", "json", "simd"]
 categories = ["algorithms", "data-structures", "parser-implementations", "parsing", "text-processing"]
 license = "MIT/Apache-2.0"
 
+[features]
+avx-accel = ["x86intrin"]
+
 [dependencies]
-x86intrin = "0.4.3"
+x86intrin = { version = "0.4.3", optional = true }
 fnv = "1.0.5"

--- a/src/emulated.rs
+++ b/src/emulated.rs
@@ -1,0 +1,63 @@
+//! emulate AVX extension for normal CPUs
+//!
+//! This is likely not as fast as using actual AVX, but will work without intrinsics.
+//! It also makes for a neat benchmark.
+
+#[allow(non_camel_case_types)]
+pub type m256i = [u64; 4];
+
+#[allow(unused_unsafe)]
+pub mod avx {
+    use super::m256i;
+
+    pub fn mm256i(x: i8) -> m256i {
+        [(x as u8) as u64 * 0x0101_0101_0101_0101_u64; 4]
+    }
+
+    fn slice_to_u64(s: &[u8]) -> u64 {
+        let mut res = 0_u64;
+        for (i, x) in s[0..8].iter().enumerate() {
+            res |= (*x as u64) << ((7 - i) * 8);
+        }
+        res
+    }
+
+
+    pub unsafe fn u8_to_m256i(s: &[u8], i: usize) -> m256i {
+        debug_assert!(i + 31 < s.len());
+        [slice_to_u64(&s[i      .. i +  8]),
+         slice_to_u64(&s[i +  8 .. i + 16]),
+         slice_to_u64(&s[i + 16 .. i + 24]),
+         slice_to_u64(&s[i + 24 .. i + 32])]
+    }
+
+    pub unsafe fn u8_to_m256i_rest(s: &[u8], i: usize) -> m256i {
+        let mut result = [0_u64; 4];
+        for x in i..s.len() {
+            result[(x - i) / 8] |= (s[x] as u64) << ((7 - ((x - i) & 7)) * 8);
+        }
+        result
+    }
+}
+
+pub fn mm256_cmpeq_epi8(x: m256i, y: m256i) -> m256i {
+    fn bytewise_equal(x: u64, y: u64) -> u64 {
+        let lo = ::std::u64::MAX / 0xFF;
+        let hi = lo << 7;
+        let x = x ^ y;
+        !((((x & !hi) + !hi) | x) >> 7) & lo
+    }
+    [bytewise_equal(x[0], y[0]),
+     bytewise_equal(x[1], y[1]),
+     bytewise_equal(x[2], y[2]),
+     bytewise_equal(x[3], y[3])]
+}
+
+pub fn mm256_movemask_epi8(x: m256i) -> u32 {
+    let factor = 0x8040_2010_0804_0201_u64;
+    ((x[0].wrapping_mul(factor) >> 56) & 0x0000_00FF_u64 |
+     (x[1].wrapping_mul(factor) >> 48) & 0x0000_FF00_u64 |
+     (x[2].wrapping_mul(factor) >> 40) & 0x00FF_0000_u64 |
+     (x[3].wrapping_mul(factor) >> 32) & 0xFF00_0000_u64) as u32
+}
+

--- a/src/index_builder.rs
+++ b/src/index_builder.rs
@@ -3,8 +3,10 @@ use super::bit;
 use super::error::ErrorKind;
 use super::result::Result;
 use super::utf8::{BACKSLASH, COLON, LEFT_BRACE, QUOTE, RIGHT_BRACE};
+#[cfg(feature = "avx-accel")]
 use x86intrin::{m256i, mm256_cmpeq_epi8, mm256_movemask_epi8};
-
+#[cfg(not(feature = "avx-accel"))]
+use emulated::{m256i, mm256_cmpeq_epi8, mm256_movemask_epi8};
 
 #[derive(Debug)]
 pub struct IndexBuilder {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,12 @@
 //! JSON parser which picks up values directly without performing tokenization
 extern crate fnv;
+#[cfg(feature = "avx-accel")]
 extern crate x86intrin;
 
+#[cfg(feature = "avx-accel")]
 mod avx;
+#[cfg(not(feature = "avx-accel"))]
+mod emulated;
 mod bit;
 mod error;
 mod index_builder;
@@ -11,6 +15,9 @@ mod pikkr;
 mod query;
 mod result;
 mod utf8;
+
+#[cfg(not(feature = "avx-accel"))]
+pub use emulated::avx;
 
 pub use error::{Error, ErrorKind};
 pub use pikkr::Pikkr;


### PR DESCRIPTION
This relegates AVX support to the `avx-accel` feature, building an "emulation" layer instead by default. I have not yet benchmarked this, but I guess it should be rather slow, but fast enough as a baseline to improve upon.