### PR TITLE
Change internal structure in `Query` and `QueryTree`

### DIFF
--- a/benches/parser.rs
+++ b/benches/parser.rs
@@ -29,7 +29,6 @@ fn basic_parse(b: &mut Bencher) {
                 &queries.as_node(),
                 0,
                 json_rec.len() - 1,
-                0,
                 false,
                 &mut results,
             )
@@ -58,7 +57,6 @@ fn speculative_parse(b: &mut Bencher) {
             &queries.as_node(),
             0,
             json_rec.len() - 1,
-            0,
             true,
             &mut results,
         )
@@ -72,7 +70,6 @@ fn speculative_parse(b: &mut Bencher) {
                 &queries.as_node(),
                 0,
                 json_rec.len() - 1,
-                0,
                 &mut results,
             )
             .unwrap();

--- a/benches/parser.rs
+++ b/benches/parser.rs
@@ -15,19 +15,18 @@ fn basic_parse(b: &mut Bencher) {
 
     let queries = QueryTree::new(query_strs).unwrap();
 
-    let l = 10;
-    let mut parser = Parser::new(l, queries.num_nodes);
+    let mut parser = Parser::new(&queries);
     parser
         .index_builder
         .build_structural_indices(json_rec)
         .unwrap();
 
     b.iter(|| {
-        let mut results = vec![None; queries.num_queries];
+        let mut results = vec![None; query_strs.len()];
         parser
             .basic_parse(
                 json_rec,
-                &queries.root,
+                &queries.as_node(),
                 0,
                 json_rec.len() - 1,
                 0,
@@ -46,18 +45,17 @@ fn speculative_parse(b: &mut Bencher) {
 
     let queries = QueryTree::new(query_strs).unwrap();
 
-    let l = 10;
-    let mut parser = Parser::new(l, queries.num_nodes);
+    let mut parser = Parser::new(&queries);
     parser
         .index_builder
         .build_structural_indices(json_rec)
         .unwrap();
 
-    let mut results = vec![None; queries.num_queries];
+    let mut results = vec![None; query_strs.len()];
     parser
         .basic_parse(
             json_rec,
-            &queries.root,
+            &queries.as_node(),
             0,
             json_rec.len() - 1,
             0,
@@ -67,11 +65,11 @@ fn speculative_parse(b: &mut Bencher) {
         .unwrap();
 
     b.iter(|| {
-        let mut results = vec![None; queries.num_queries];
+        let mut results = vec![None; query_strs.len()];
         parser
             .speculative_parse(
                 json_rec,
-                &queries.root,
+                &queries.as_node(),
                 0,
                 json_rec.len() - 1,
                 0,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -26,7 +26,9 @@ impl Parser {
     }
 
     #[inline]
-    pub fn basic_parse<'a>(&mut self, rec: &'a [u8], queries: &QueryNode, start: usize, end: usize, level: usize, set_stats: bool, results: &mut Vec<Option<&'a [u8]>>) -> Result<()> {
+    pub fn basic_parse<'a>(&mut self, rec: &'a [u8], queries: &QueryNode, start: usize, end: usize, set_stats: bool, results: &mut Vec<Option<&'a [u8]>>) -> Result<()> {
+        let level = queries.level();
+
         generate_colon_positions(
             &self.index_builder.index,
             start,
@@ -61,7 +63,7 @@ impl Parser {
                     self.stats[query.id()].insert(i);
                 }
                 if !query.is_leaf() {
-                    self.basic_parse(rec, query, vsi, vei, level + 1, set_stats, results)?;
+                    self.basic_parse(rec, query, vsi, vei, set_stats, results)?;
                 }
                 if let Some(i) = query.path_id() {
                     results[i] = Some(&rec[vsi..vei + 1]);
@@ -76,7 +78,9 @@ impl Parser {
     }
 
     #[inline]
-    pub fn speculative_parse<'a>(&self, rec: &'a [u8], queries: &QueryNode, start: usize, end: usize, level: usize, results: &mut Vec<Option<&'a [u8]>>) -> Result<bool> {
+    pub fn speculative_parse<'a>(&self, rec: &'a [u8], queries: &QueryNode, start: usize, end: usize, results: &mut Vec<Option<&'a [u8]>>) -> Result<bool> {
+        let level = queries.level();
+
         generate_colon_positions(
             &self.index_builder.index,
             start,
@@ -120,7 +124,7 @@ impl Parser {
                         if i == cp_len - 1 { RIGHT_BRACE } else { COMMA },
                     )?;
                     if !q.is_leaf() {
-                        found = self.speculative_parse(rec, q, vsi, vei, level + 1, results)?;
+                        found = self.speculative_parse(rec, q, vsi, vei, results)?;
                     } else {
                         found = true;
                     }
@@ -259,7 +263,6 @@ mod tests {
             &queries.as_node(),
             0,
             json_rec.len() - 1,
-            0,
             true,
             &mut results,
         );

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,7 +1,7 @@
 use super::bit;
 use super::error::{Error, ErrorKind};
 use super::index_builder::IndexBuilder;
-use super::query::{Query, QueryTree};
+use super::query::{QueryNode, QueryTree};
 use super::result::Result;
 use super::utf8::{COMMA, CR, HT, LF, RIGHT_BRACE, SPACE};
 use fnv::FnvHashSet;
@@ -26,16 +26,7 @@ impl Parser {
     }
 
     #[inline]
-    pub fn basic_parse<'a>(
-        &mut self,
-        rec: &'a [u8],
-        queries: &Query,
-        start: usize,
-        end: usize,
-        level: usize,
-        set_stats: bool,
-        results: &mut Vec<Option<&'a [u8]>>,
-    ) -> Result<()> {
+    pub fn basic_parse<'a>(&mut self, rec: &'a [u8], queries: &QueryNode, start: usize, end: usize, level: usize, set_stats: bool, results: &mut Vec<Option<&'a [u8]>>) -> Result<()> {
         generate_colon_positions(
             &self.index_builder.index,
             start,
@@ -85,7 +76,7 @@ impl Parser {
     }
 
     #[inline]
-    pub fn speculative_parse<'a>(&self, rec: &'a [u8], queries: &Query, start: usize, end: usize, level: usize, results: &mut Vec<Option<&'a [u8]>>) -> Result<bool> {
+    pub fn speculative_parse<'a>(&self, rec: &'a [u8], queries: &QueryNode, start: usize, end: usize, level: usize, results: &mut Vec<Option<&'a [u8]>>) -> Result<bool> {
         generate_colon_positions(
             &self.index_builder.index,
             start,

--- a/src/pikkr.rs
+++ b/src/pikkr.rs
@@ -54,21 +54,14 @@ impl<'a> Pikkr<'a> {
 
     fn speculative_parse<'b>(&mut self, rec: &'b [u8]) -> Result<Vec<Option<&'b [u8]>>> {
         let mut results = vec![None; self.queries.num_paths()];
-        let found = self.parser.speculative_parse(
-            rec,
-            &self.queries.as_node(),
-            0,
-            rec.len() - 1,
-            0,
-            &mut results,
-        )?;
+        let found = self.parser
+            .speculative_parse(rec, &self.queries.as_node(), 0, rec.len() - 1, &mut results)?;
         if !found {
             self.parser.basic_parse(
                 rec,
                 &self.queries.as_node(),
                 0,
                 rec.len() - 1,
-                0,
                 false,
                 &mut results,
             )?;
@@ -83,7 +76,6 @@ impl<'a> Pikkr<'a> {
             &self.queries.as_node(),
             0,
             rec.len() - 1,
-            0,
             true,
             &mut results,
         )?;

--- a/src/query.rs
+++ b/src/query.rs
@@ -10,7 +10,7 @@ const ROOT_QUERY_STR_OFFSET: usize = 2;
 
 /// A node in pattern tree
 #[derive(Debug, Default)]
-pub struct Query<'a> {
+pub struct QueryNode<'a> {
     /// The identifier of this node
     node_id: Option<usize>,
 
@@ -18,10 +18,10 @@ pub struct Query<'a> {
     path_id: Option<usize>,
 
     /// Children of this node
-    children: FnvHashMap<&'a [u8], Query<'a>>,
+    children: FnvHashMap<&'a [u8], QueryNode<'a>>,
 }
 
-impl<'a> Query<'a> {
+impl<'a> QueryNode<'a> {
     /// Returns whether this node is a leaf or not.
     #[inline]
     pub fn is_leaf(&self) -> bool {
@@ -55,7 +55,7 @@ impl<'a> Query<'a> {
 
     /// Returns the reference of a child whose filed name is `field`, if available.
     #[inline]
-    pub fn get_child(&self, field: &[u8]) -> Option<&Query> {
+    pub fn get_child(&self, field: &[u8]) -> Option<&QueryNode> {
         self.children.get(field)
     }
 
@@ -68,7 +68,7 @@ impl<'a> Query<'a> {
     }
 
     #[inline]
-    pub fn iter(&self) -> hash_map::Iter<&'a [u8], Query<'a>> {
+    pub fn iter(&self) -> hash_map::Iter<&'a [u8], QueryNode<'a>> {
         self.children.iter()
     }
 }
@@ -77,7 +77,7 @@ impl<'a> Query<'a> {
 /// A pattern tree associated with the queries
 #[derive(Debug, Default)]
 pub struct QueryTree<'a> {
-    root_node: Query<'a>,
+    root_node: QueryNode<'a>,
     paths: Vec<&'a [u8]>,
     max_level: usize,
     num_nodes: usize,
@@ -107,7 +107,7 @@ impl<'a> QueryTree<'a> {
             let num_nodes = &mut self.num_nodes;
             let cur1 = cur; // workaround for lifetime error
             cur = cur1.children.entry(field).or_insert_with(|| {
-                let node = Query {
+                let node = QueryNode {
                     node_id: Some(*num_nodes),
                     ..Default::default()
                 };
@@ -126,7 +126,7 @@ impl<'a> QueryTree<'a> {
 
     /// Returns the reference of root node of this pattern tree.
     #[inline]
-    pub fn as_node(&self) -> &Query {
+    pub fn as_node(&self) -> &QueryNode {
         &self.root_node
     }
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,4 +1,5 @@
 use std::cmp;
+use std::collections::hash_map;
 use fnv::FnvHashMap;
 use error::{Error, ErrorKind};
 use result::Result;
@@ -7,53 +8,144 @@ use utf8::{DOLLAR, DOT};
 const ROOT_QUERY_STR_OFFSET: usize = 2;
 
 
-#[derive(Debug)]
+/// A node in pattern tree
+#[derive(Debug, Default)]
 pub struct Query<'a> {
-    pub i: usize,
-    pub ri: usize,
-    pub target: bool,
-    pub children: Option<FnvHashMap<&'a [u8], Query<'a>>>,
+    /// The identifier of this node
+    node_id: Option<usize>,
+
+    /// A identifier of path associated with this node
+    path_id: Option<usize>,
+
+    /// Children of this node
+    children: FnvHashMap<&'a [u8], Query<'a>>,
 }
 
+impl<'a> Query<'a> {
+    /// Returns whether this node is a leaf or not.
+    #[inline]
+    pub fn is_leaf(&self) -> bool {
+        self.children.is_empty()
+    }
+
+    /// Returns the identifier of this node, if avaialble.
+    ///
+    /// This function will return a `None` if the node is root.
+    #[inline]
+    pub fn node_id(&self) -> Option<usize> {
+        self.node_id
+    }
+
+    /// Returns the identifier of this node.
+    ///
+    /// # Panics
+    /// This function will panic if the node is root.
+    #[inline]
+    pub fn id(&self) -> usize {
+        self.node_id.expect("The node is a root")
+    }
+
+    /// Returns the path identifier associated with this node.
+    ///
+    /// This function will return a `None` if the node is not a target.
+    #[inline]
+    pub fn path_id(&self) -> Option<usize> {
+        self.path_id
+    }
+
+    /// Returns the reference of a child whose filed name is `field`, if available.
+    #[inline]
+    pub fn get_child(&self, field: &[u8]) -> Option<&Query> {
+        self.children.get(field)
+    }
+
+    /// Returns the number of childrens of this node.
+    ///
+    /// This function will return a zero if it is a leaf.
+    #[inline]
+    pub fn num_children(&self) -> usize {
+        self.children.len()
+    }
+
+    #[inline]
+    pub fn iter(&self) -> hash_map::Iter<&'a [u8], Query<'a>> {
+        self.children.iter()
+    }
+}
+
+
 /// A pattern tree associated with the queries
+#[derive(Debug, Default)]
 pub struct QueryTree<'a> {
-    pub root: FnvHashMap<&'a [u8], Query<'a>>,
-    pub num_queries: usize,
-    pub max_depth: usize,
-    pub num_nodes: usize,
+    root_node: Query<'a>,
+    paths: Vec<&'a [u8]>,
+    max_level: usize,
+    num_nodes: usize,
 }
 
 impl<'a> QueryTree<'a> {
-    pub fn new<S: ?Sized + AsRef<[u8]>>(queries: &[&'a S]) -> Result<Self> {
-        let mut root = FnvHashMap::default();
-        let mut level = 0;
-        let mut qi = 0;
+    /// Create a new instance of `QueryTree` with given path sequence.
+    pub fn new<S: ?Sized + AsRef<[u8]>>(paths: &[&'a S]) -> Result<Self> {
+        let mut tree = Self::default();
+        for path in paths {
+            tree.add_path((*path).as_ref())?;
+        }
+        Ok(tree)
+    }
 
-        for (ri, s) in queries.into_iter().map(|s| (*s).as_ref()).enumerate() {
-            if !is_valid_query_str(s) {
-                return Err(Error::from(ErrorKind::InvalidQuery));
-            }
-
-            let l = set_queries(&mut root, &s[ROOT_QUERY_STR_OFFSET..], || {
-                let query = Query {
-                    i: qi,
-                    ri,
-                    target: false,
-                    children: None,
-                };
-                qi += 1;
-                query
-            });
-
-            level = cmp::max(level, l);
+    /// Add a path into the pattern tree.
+    fn add_path(&mut self, path: &'a [u8]) -> Result<()> {
+        if !is_valid_query_str(path) {
+            return Err(Error::from(ErrorKind::InvalidQuery));
         }
 
-        Ok(Self {
-            root,
-            num_queries: queries.len(),
-            max_depth: level,
-            num_nodes: qi,
-        })
+        let mut cur = &mut self.root_node;
+        let mut level = 0;
+        for field in path[ROOT_QUERY_STR_OFFSET..].split(|&b| b == DOT) {
+            level = level + 1;
+
+            let num_nodes = &mut self.num_nodes;
+            let cur1 = cur; // workaround for lifetime error
+            cur = cur1.children.entry(field).or_insert_with(|| {
+                let node = Query {
+                    node_id: Some(*num_nodes),
+                    ..Default::default()
+                };
+                *num_nodes += 1;
+                node
+            });
+        }
+        // mark the last node as a target
+        cur.path_id = Some(self.paths.len());
+
+        self.max_level = cmp::max(self.max_level, level);
+        self.paths.push(path);
+
+        Ok(())
+    }
+
+    /// Returns the reference of root node of this pattern tree.
+    #[inline]
+    pub fn as_node(&self) -> &Query {
+        &self.root_node
+    }
+
+    /// Returns the max level of pattern tree.
+    #[inline]
+    pub fn max_level(&self) -> usize {
+        self.max_level
+    }
+
+    /// Returns the number of query paths, registered in this pattern tree.
+    #[inline]
+    pub fn num_paths(&self) -> usize {
+        self.paths.len()
+    }
+
+    /// Returns the number of nodes excluding root node in this pattern tree.
+    #[inline]
+    pub fn num_nodes(&self) -> usize {
+        self.num_nodes
     }
 }
 
@@ -73,25 +165,6 @@ fn is_valid_query_str(query_str: &[u8]) -> bool {
         s = i;
     }
     true
-}
-
-#[inline]
-fn set_queries<'a, F>(queries: &mut FnvHashMap<&'a [u8], Query<'a>>, s: &'a [u8], mut factory: F) -> usize
-where
-    F: FnMut() -> Query<'a>,
-{
-    let j = s.iter().position(|&c| c == DOT).unwrap_or(s.len());
-    let (t, u) = s.split_at(j);
-
-    let query = queries.entry(t).or_insert_with(&mut factory);
-    if u.len() > 1 {
-        // The remaining segments are exist
-        let children = query.children.get_or_insert(FnvHashMap::default());
-        set_queries(children, &u[1..], factory) + 1
-    } else {
-        query.target = true; // mark the node as a target node
-        1
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
It also renames `Query` to `QueryNode`, to clarify the role of them as a node in pattern tree.
Note that the argument `level` in `Parser::basic_parse()` and `Parser::speculative_parse()` has also moved to `QueryNode`, because they are the same as the level of node in pattern tree.